### PR TITLE
[CI] Publish to PyPI upon Tag

### DIFF
--- a/.github/workflows/lint_and_format.yml
+++ b/.github/workflows/lint_and_format.yml
@@ -2,7 +2,7 @@ name: Ruff
 on: pull_request
 jobs:
   lint:
-    name: Lint, Format, and Commit
+    name: Lint & Format
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -1,0 +1,40 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  pypi:
+    runs-on: ubuntu-latest
+    steps:
+      # ----------------
+      # Set Up
+      # ----------------
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: 1.5.1
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+      - name: Install PyPI Credential
+        run: poetry config pypi-token.pypi ${{ secrets.PYPI_API_TOKEN }}
+      # ----------------
+      # Install Deps
+      # ----------------
+      - name: Install Dependencies
+        run: poetry install --no-interaction --no-root
+      # ----------------
+      # Build & Publish
+      # ----------------
+      - name: Build & Publish
+        run: make build-release

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -1,9 +1,7 @@
 name: Publish to PyPI
-
 on:
   release:
     types: [published]
-
 jobs:
   pypi:
     runs-on: ubuntu-latest
@@ -26,13 +24,16 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
-      - name: Install PyPI Credential
-        run: poetry config pypi-token.pypi ${{ secrets.PYPI_API_TOKEN }}
       # ----------------
       # Install Deps
       # ----------------
       - name: Install Dependencies
-        run: poetry install --no-interaction --no-root
+        run: |
+          poetry install --no-interaction --no-root
+          poetry self add "poetry-dynamic-versioning[plugin]"
+      - name: Install PyPI Credential
+        run: |
+          poetry config pypi-token ${{ secrets.PYPI_API_TOKEN }}
       # ----------------
       # Build & Publish
       # ----------------

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -1,10 +1,16 @@
-name: Publish to PyPI
+name: PyPI CD
 on:
   release:
     types: [published]
 jobs:
   pypi:
+    name: Build and Upload Release
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/llm-toolkit
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
       # ----------------
       # Set Up
@@ -31,11 +37,10 @@ jobs:
         run: |
           poetry install --no-interaction --no-root
           poetry self add "poetry-dynamic-versioning[plugin]"
-      - name: Install PyPI Credential
-        run: |
-          poetry config pypi-token ${{ secrets.PYPI_API_TOKEN }}
       # ----------------
       # Build & Publish
       # ----------------
-      - name: Build & Publish
-        run: make build-release
+      - name: Build
+        run: poetry build
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/llmtune/__init__.py
+++ b/llmtune/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2024 Georgian Partners
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ llmtune = "llmtune.cli.toolkit:cli"
 enable = true
 vcs = "git"
 style = "semver"
+pattern = "default-unprefixed"
 
 [tool.poetry-dynamic-versioning.substitution]
 folders = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "llm-toolkit"
-version = "0.1.0"
+version = "0.0.0"
 description = "LLM Finetuning resource hub + toolkit"
 authors = ["Benjamin Ye <benjamin.ye@georgian.io>"]
 license = "Apache 2.0"
@@ -9,6 +9,9 @@ packages = [{include = "llmtune"}]
 
 [tool.poetry.scripts]
 llmtune = "llmtune.cli.toolkit:cli"
+
+[tool.poetry-dynamic-versioning]
+enable = true
 
 [tool.poetry.dependencies]
 python = ">=3.9, <=3.12"
@@ -49,8 +52,8 @@ shellingham = "^1.5.4"
 ruff = "~0.3.5"
 
 [build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
+build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.ruff]
 lint.ignore = ["C901", "E501", "E741", "F402", "F823" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ llmtune = "llmtune.cli.toolkit:cli"
 enable = true
 vcs = "git"
 style = "semver"
-pattern = "default-unprefixed"
 
 [tool.poetry-dynamic-versioning.substitution]
 folders = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,13 @@ llmtune = "llmtune.cli.toolkit:cli"
 
 [tool.poetry-dynamic-versioning]
 enable = true
+vcs = "git"
+style = "semver"
+
+[tool.poetry-dynamic-versioning.substitution]
+folders = [
+  { path = "llmtune" }
+]
 
 [tool.poetry.dependencies]
 python = ">=3.9, <=3.12"


### PR DESCRIPTION
This PR introduces CI pipeline for PyPI. Addresses https://github.com/georgian-io/LLM-Finetuning-Hub/issues/114, https://github.com/georgian-io/LLM-Finetuning-Hub/issues/106.

## What does this PR do?
- Establish `git tags` as single source of truth for package releases and versioning

- Workflow is triggered when
  - using Github web UI to tag and publish a new release 
![image](https://github.com/georgian-io/LLM-Finetuning-Hub/assets/17937357/f71e2efc-0730-4ac6-8d13-a79bf16fcb73)
  - using Github CLI to publish a new release
    - e.g. `gh release create --repo seanh/gha-python-packaging-demo --generate-notes 0.0.1` 

- Dynamic versioning and version convention (Semver) enforcement via [poetry plugin](https://pypi.org/project/poetry-dynamic-versioning/)
  - Version specified by `tag` will be replacing values found within `pyproject.toml` as well as in any `__init__.py` files (i.e. where we do `__version__='0.0.0'`). 


## Requirement
- @truskovskiyk or @RohitSaha, please add a [github repo secret](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions) `PYPI_API_TOKEN` with a (preferably) scoped PyPI API Token.