### PR TITLE
[CI] Publish to Github Packages (ghcr)

### DIFF
--- a/.github/workflows/publish_to_ghcr.yml
+++ b/.github/workflows/publish_to_ghcr.yml
@@ -20,9 +20,15 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Build and push Docker image
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: .
           push: true
-          tags: ${{ github.ref_name }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish_to_ghcr.yml
+++ b/.github/workflows/publish_to_ghcr.yml
@@ -1,0 +1,34 @@
+name: Publish Docker Image
+on:
+  release:
+    types: [published]
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish_to_ghcr.yml
+++ b/.github/workflows/publish_to_ghcr.yml
@@ -20,15 +20,9 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-      - name: Build and push Docker image
+     - name: Build and push Docker image
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ github.ref_name }}

--- a/.github/workflows/publish_to_ghcr.yml
+++ b/.github/workflows/publish_to_ghcr.yml
@@ -1,4 +1,4 @@
-name: Publish Docker Image
+name: Github Packages CD
 on:
   release:
     types: [published]
@@ -7,6 +7,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 jobs:
   build-and-push-image:
+    name: Build and Push Image
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/publish_to_ghcr.yml
+++ b/.github/workflows/publish_to_ghcr.yml
@@ -20,7 +20,7 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-     - name: Build and push Docker image
+      - name: Build and push Docker image
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: .


### PR DESCRIPTION
This PR introduces CI pipeline for building and publishing docker image. Addresses https://github.com/georgian-io/LLM-Finetuning-Hub/issues/106, https://github.com/georgian-io/LLM-Finetuning-Hub/issues/109.

## What does this PR do
- Workflow trigger is the same as https://github.com/georgian-io/LLM-Finetuning-Hub/pull/121
- This is basically the same as the workflow from this [github dev guide](https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#publishing-a-package-using-an-action)

## Requirement
- ~@RohitSaha, @truskovskiyk, add a `GITHUB_TOKEN` secret with `contents: read` and `packages: write` permissions.~
- No longer need this