### PR TITLE
Moving metrics to metrics and adding pass/fail LLM tests

### DIFF
--- a/llmtune/cli/toolkit.py
+++ b/llmtune/cli/toolkit.py
@@ -15,8 +15,8 @@ from llmtune.data.dataset_generator import DatasetGenerator
 from llmtune.finetune.lora import LoRAFinetune
 from llmtune.inference.lora import LoRAInference
 from llmtune.pydantic_models.config_model import Config
-from llmtune.qa.generics import LLMTestSuite
-from llmtune.qa.qa_tests import QaTestRegistry
+from llmtune.qa.generics import LLMMetricSuite
+from llmtune.qa.qa_metrics import QaMetricRegistry
 from llmtune.ui.rich_ui import RichUI
 from llmtune.utils.ablation_utils import generate_permutations
 from llmtune.utils.save_utils import DirectoryHelper
@@ -91,10 +91,10 @@ def run_one_experiment(config: Config, config_path: Path) -> None:
     qa_file_path = dir_helper.save_paths.qa_file
     if not qa_file_path.exists():
         llm_metrics = config.qa.llm_metrics
-        tests = QaTestRegistry.create_tests_from_list(llm_metrics)
-        test_suite = LLMTestSuite.from_csv(results_file_path, tests)
-        test_suite.save_test_results(qa_file_path)
-        test_suite.print_test_results()
+        tests = QaMetricRegistry.create_tests_from_list(llm_metrics)
+        test_suite = LLMMetricSuite.from_csv(results_file_path, tests)
+        test_suite.save_metric_results(qa_file_path)
+        test_suite.print_metric_results()
 
 
 @app.command("run")

--- a/llmtune/qa/generics.py
+++ b/llmtune/qa/generics.py
@@ -1,5 +1,4 @@
 import statistics
-from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Dict, List, Union
 
@@ -14,6 +13,7 @@ class LLMMetricSuite:
     Represents and runs a suite of metrics on a set of prompts,
     golden responses, and model predictions.
     """
+
     def __init__(
         self,
         metrics: List[LLMQaMetric],

--- a/llmtune/qa/generics.py
+++ b/llmtune/qa/generics.py
@@ -5,66 +5,60 @@ from typing import Dict, List, Union
 
 import pandas as pd
 
+from llmtune.qa.qa_metrics import LLMQaMetric
 from llmtune.ui.rich_ui import RichUI
 
 
-class LLMQaTest(ABC):
-    @property
-    @abstractmethod
-    def test_name(self) -> str:
-        pass
-
-    @abstractmethod
-    def get_metric(self, prompt: str, grount_truth: str, model_pred: str) -> Union[float, int, bool]:
-        pass
-
-
-class LLMTestSuite:
+class LLMMetricSuite:
+    """
+    Represents and runs a suite of metrics on a set of prompts,
+    golden responses, and model predictions.
+    """
     def __init__(
         self,
-        tests: List[LLMQaTest],
+        metrics: List[LLMQaMetric],
         prompts: List[str],
         ground_truths: List[str],
         model_preds: List[str],
     ) -> None:
-        self.tests = tests
+        self.metrics = metrics
         self.prompts = prompts
         self.ground_truths = ground_truths
         self.model_preds = model_preds
 
-        self._results = {}
+        self._results: Dict[str, List[Union[float, int]]] = {}
 
     @staticmethod
     def from_csv(
         file_path: str,
-        tests: List[LLMQaTest],
+        metrics: List[LLMQaMetric],
         prompt_col: str = "Prompt",
         gold_col: str = "Ground Truth",
         pred_col="Predicted",
-    ) -> "LLMTestSuite":
+    ) -> "LLMMetricSuite":
         results_df = pd.read_csv(file_path)
         prompts = results_df[prompt_col].tolist()
         ground_truths = results_df[gold_col].tolist()
         model_preds = results_df[pred_col].tolist()
-        return LLMTestSuite(tests, prompts, ground_truths, model_preds)
+        return LLMMetricSuite(metrics, prompts, ground_truths, model_preds)
 
-    def run_tests(self) -> Dict[str, List[Union[float, int, bool]]]:
-        test_results = {}
-        for test in self.tests:
-            metrics = []
+    def compute_metrics(self) -> Dict[str, List[Union[float, int]]]:
+        results = {}
+        for metric in self.metrics:
+            metric_results = []
             for prompt, ground_truth, model_pred in zip(self.prompts, self.ground_truths, self.model_preds):
-                metrics.append(test.get_metric(prompt, ground_truth, model_pred))
-            test_results[test.test_name] = metrics
+                metric_results.append(metric.get_metric(prompt, ground_truth, model_pred))
+            results[metric.metric_name] = metric_results
 
-        self._results = test_results
-        return test_results
+        self._results = results
+        return results
 
     @property
-    def test_results(self):
-        return self._results if self._results else self.run_tests()
+    def metric_results(self) -> Dict[str, List[Union[float, int]]]:
+        return self._results if self._results else self.compute_metrics()
 
-    def print_test_results(self):
-        result_dictionary = self.test_results
+    def print_metric_results(self):
+        result_dictionary = self.metric_results
         column_data = {key: list(result_dictionary[key]) for key in result_dictionary}
         mean_values = {key: statistics.mean(column_data[key]) for key in column_data}
         median_values = {key: statistics.median(column_data[key]) for key in column_data}
@@ -72,7 +66,7 @@ class LLMTestSuite:
         # Use the RichUI class to display the table
         RichUI.qa_display_metric_table(result_dictionary, mean_values, median_values, stdev_values)
 
-    def save_test_results(self, path: str):
+    def save_metric_results(self, path: str):
         # TODO: save these!
         path = Path(path)
         dir = path.parent
@@ -80,5 +74,5 @@ class LLMTestSuite:
         if not dir.exists():
             dir.mkdir(parents=True, exist_ok=True)
 
-        resultant_dataframe = pd.DataFrame(self.test_results)
+        resultant_dataframe = pd.DataFrame(self.metric_results)
         resultant_dataframe.to_csv(path, index=False)

--- a/llmtune/qa/qa_metrics.py
+++ b/llmtune/qa/qa_metrics.py
@@ -24,6 +24,7 @@ class LLMQaMetric(ABC):
     Abstract base class for a metric. A metric can be computed over a single
     data instance, and outputs a scalar value (integer or float).
     """
+
     @property
     @abstractmethod
     def metric_name(self) -> str:
@@ -82,6 +83,7 @@ class JaccardSimilarityMetric(LLMQaMetric):
 class DotProductSimilarityMetric(LLMQaMetric):
     """Encodes both the ground truth and model prediction using DistilBERT, and
     computes the dot product similarity between the two embeddings."""
+
     def __init__(self):
         model_name = "distilbert-base-uncased"
         self.tokenizer = DistilBertTokenizer.from_pretrained(model_name)

--- a/llmtune/qa/qa_metrics.py
+++ b/llmtune/qa/qa_metrics.py
@@ -1,0 +1,208 @@
+from abc import ABC, abstractmethod
+from typing import List, Union
+
+import nltk
+import numpy as np
+import torch
+from langchain.evaluation import JsonValidityEvaluator
+from nltk import pos_tag
+from nltk.corpus import stopwords
+from nltk.tokenize import word_tokenize
+from rouge_score import rouge_scorer
+from transformers import DistilBertModel, DistilBertTokenizer
+
+
+json_validity_evaluator = JsonValidityEvaluator()
+
+nltk.download("stopwords")
+nltk.download("punkt")
+nltk.download("averaged_perceptron_tagger")
+
+
+class LLMQaMetric(ABC):
+    """
+    Abstract base class for a metric. A metric can be computed over a single
+    data instance, and outputs a scalar value (integer or float).
+    """
+    @property
+    @abstractmethod
+    def metric_name(self) -> str:
+        pass
+
+    @abstractmethod
+    def get_metric(self, prompt: str, grount_truth: str, model_pred: str) -> Union[float, int]:
+        pass
+
+
+class QaMetricRegistry:
+    registry = {}
+
+    @classmethod
+    def register(cls, *names):
+        def inner_wrapper(wrapped_class):
+            for name in names:
+                cls.registry[name] = wrapped_class
+            return wrapped_class
+
+        return inner_wrapper
+
+    @classmethod
+    def create_tests_from_list(cls, metric_names: List[str]) -> List[LLMQaMetric]:
+        return [cls.registry[test]() for test in metric_names]
+
+
+@QaMetricRegistry.register("summary_length")
+class LengthMetric(LLMQaMetric):
+    @property
+    def metric_name(self) -> str:
+        return "summary_length"
+
+    def get_metric(self, prompt: str, ground_truth: str, model_prediction: str) -> Union[float, int, bool]:
+        return abs(len(ground_truth) - len(model_prediction))
+
+
+@QaMetricRegistry.register("jaccard_similarity")
+class JaccardSimilarityMetric(LLMQaMetric):
+    @property
+    def metric_name(self) -> str:
+        return "jaccard_similarity"
+
+    def get_metric(self, prompt: str, ground_truth: str, model_prediction: str) -> Union[float, int, bool]:
+        set_ground_truth = set(ground_truth.lower())
+        set_model_prediction = set(model_prediction.lower())
+
+        intersection_size = len(set_ground_truth.intersection(set_model_prediction))
+        union_size = len(set_ground_truth.union(set_model_prediction))
+
+        similarity = intersection_size / union_size if union_size != 0 else 0
+        return float(similarity)
+
+
+@QaMetricRegistry.register("dot_product")
+class DotProductSimilarityMetric(LLMQaMetric):
+    """Encodes both the ground truth and model prediction using DistilBERT, and
+    computes the dot product similarity between the two embeddings."""
+    def __init__(self):
+        model_name = "distilbert-base-uncased"
+        self.tokenizer = DistilBertTokenizer.from_pretrained(model_name)
+        self.model = DistilBertModel.from_pretrained(model_name)
+
+    @property
+    def metric_name(self) -> str:
+        return "dot_product"
+
+    def _encode_sentence(self, sentence):
+        tokens = self.tokenizer(sentence, return_tensors="pt")
+        with torch.no_grad():
+            outputs = self.model(**tokens)
+        return outputs.last_hidden_state.mean(dim=1).squeeze().numpy()
+
+    def get_metric(self, prompt: str, ground_truth: str, model_prediction: str) -> Union[float, int, bool]:
+        embedding_ground_truth = self._encode_sentence(ground_truth)
+        embedding_model_prediction = self._encode_sentence(model_prediction)
+        dot_product_similarity = np.dot(embedding_ground_truth, embedding_model_prediction)
+        return float(dot_product_similarity)
+
+
+@QaMetricRegistry.register("rouge_score")
+class RougeScoreMetric(LLMQaMetric):
+    @property
+    def metric_name(self) -> str:
+        return "rouge_score"
+
+    def get_metric(self, prompt: str, ground_truth: str, model_prediction: str) -> Union[float, int, bool]:
+        scorer = rouge_scorer.RougeScorer(["rouge1"], use_stemmer=True)
+        scores = scorer.score(model_prediction, ground_truth)
+        return float(scores["rouge1"].precision)
+
+
+@QaMetricRegistry.register("word_overlap")
+class WordOverlapMetric(LLMQaMetric):
+    @property
+    def metric_name(self) -> str:
+        return "word_overlap"
+
+    def _remove_stopwords(self, text: str) -> str:
+        stop_words = set(stopwords.words("english"))
+        word_tokens = word_tokenize(text)
+        filtered_text = [word for word in word_tokens if word.lower() not in stop_words]
+        return " ".join(filtered_text)
+
+    def get_metric(self, prompt: str, ground_truth: str, model_prediction: str) -> Union[float, int, bool]:
+        cleaned_model_prediction = self._remove_stopwords(model_prediction)
+        cleaned_ground_truth = self._remove_stopwords(ground_truth)
+
+        words_model_prediction = set(cleaned_model_prediction.split())
+        words_ground_truth = set(cleaned_ground_truth.split())
+
+        common_words = words_model_prediction.intersection(words_ground_truth)
+        overlap_percentage = (len(common_words) / len(words_ground_truth)) * 100
+        return float(overlap_percentage)
+
+
+@QaMetricRegistry.register("json_valid")
+class JSONValidityMetric(LLMQaMetric):
+    """
+    Checks to see if valid json can be parsed from the model output, according
+    to langchain_core.utils.json.parse_json_markdown
+    The JSON can be wrapped in markdown and this test will still pass
+    """
+
+    @property
+    def metric_name(self) -> str:
+        return "json_valid"
+
+    def get_metric(self, prompt: str, ground_truth: str, model_prediction: str) -> float:
+        result = json_validity_evaluator.evaluate_strings(prediction=model_prediction)
+        binary_res = result["score"]
+        return float(binary_res)
+
+
+class PosCompositionMetric(LLMQaMetric):
+    def _get_pos_percent(self, text: str, pos_tags: List[str]) -> float:
+        words = word_tokenize(text)
+        tags = pos_tag(words)
+        pos_words = [word for word, tag in tags if tag in pos_tags]
+        total_words = len(text.split(" "))
+        return round(len(pos_words) / total_words, 2)
+
+
+@QaMetricRegistry.register("verb_percent")
+class VerbPercentMetric(PosCompositionMetric):
+    @property
+    def metric_name(self) -> str:
+        return "verb_percent"
+
+    def get_metric(self, prompt: str, ground_truth: str, model_prediction: str) -> float:
+        return self._get_pos_percent(model_prediction, ["VB", "VBD", "VBG", "VBN", "VBP", "VBZ"])
+
+
+@QaMetricRegistry.register("adjective_percent")
+class AdjectivePercentMetric(PosCompositionMetric):
+    @property
+    def metric_name(self) -> str:
+        return "adjective_percent"
+
+    def get_metric(self, prompt: str, ground_truth: str, model_prediction: str) -> float:
+        return self._get_pos_percent(model_prediction, ["JJ", "JJR", "JJS"])
+
+
+@QaMetricRegistry.register("noun_percent")
+class NounPercentMetric(PosCompositionMetric):
+    @property
+    def metric_name(self) -> str:
+        return "noun_percent"
+
+    def get_metric(self, prompt: str, ground_truth: str, model_prediction: str) -> float:
+        return self._get_pos_percent(model_prediction, ["NN", "NNS", "NNP", "NNPS"])
+
+
+# Instantiate tests
+# length_test = LengthMetric()
+# jaccard_similarity_test = JaccardSimilarityMetric()
+# dot_product_similarity_test = DotProductSimilarityMetric()
+# rouge_score_test = RougeScoreMetric()
+# word_overlap_test = WordOverlapMetric()
+# verb_percent_test = VerbPercentMetric()
+# adjective_percent_test = AdjectivePercentMetric()
+# noun_percent_test = NounPercentMetric()

--- a/llmtune/qa/qa_tests.py
+++ b/llmtune/qa/qa_tests.py
@@ -1,190 +1,38 @@
+from abc import ABC, abstractmethod
 from typing import List, Union
 
-import nltk
-import numpy as np
-import torch
 from langchain.evaluation import JsonValidityEvaluator
-from nltk import pos_tag
-from nltk.corpus import stopwords
-from nltk.tokenize import word_tokenize
-from rouge_score import rouge_scorer
-from transformers import DistilBertModel, DistilBertTokenizer
-
-from llmtune.qa.generics import LLMQaTest
 
 
-json_validity_evaluator = JsonValidityEvaluator()
-model_name = "distilbert-base-uncased"
-tokenizer = DistilBertTokenizer.from_pretrained(model_name)
-model = DistilBertModel.from_pretrained(model_name)
-
-nltk.download("stopwords")
-nltk.download("punkt")
-nltk.download("averaged_perceptron_tagger")
-
-
-class QaTestRegistry:
-    registry = {}
-
-    @classmethod
-    def register(cls, *names):
-        def inner_wrapper(wrapped_class):
-            for name in names:
-                cls.registry[name] = wrapped_class
-            return wrapped_class
-
-        return inner_wrapper
-
-    @classmethod
-    def create_tests_from_list(cls, test_names: List[str]) -> List[LLMQaTest]:
-        return [cls.registry[test]() for test in test_names]
-
-
-@QaTestRegistry.register("summary_length")
-class LengthTest(LLMQaTest):
+class LLMQaTest(ABC):
+    """
+    Abstract base class for a test. A test can be computed over a single
+    data instance/llm response, and outputs a boolean value (pass or fail).
+    """
     @property
+    @abstractmethod
     def test_name(self) -> str:
-        return "summary_length"
+        pass
 
-    def get_metric(self, prompt: str, ground_truth: str, model_prediction: str) -> Union[float, int, bool]:
-        return abs(len(ground_truth) - len(model_prediction))
-
-
-@QaTestRegistry.register("jaccard_similarity")
-class JaccardSimilarityTest(LLMQaTest):
-    @property
-    def test_name(self) -> str:
-        return "jaccard_similarity"
-
-    def get_metric(self, prompt: str, ground_truth: str, model_prediction: str) -> Union[float, int, bool]:
-        set_ground_truth = set(ground_truth.lower())
-        set_model_prediction = set(model_prediction.lower())
-
-        intersection_size = len(set_ground_truth.intersection(set_model_prediction))
-        union_size = len(set_ground_truth.union(set_model_prediction))
-
-        similarity = intersection_size / union_size if union_size != 0 else 0
-        return float(similarity)
+    @abstractmethod
+    def test(self, prompt: str, grount_truth: str, model_pred: str) -> bool:
+        pass
 
 
-@QaTestRegistry.register("dot_product")
-class DotProductSimilarityTest(LLMQaTest):
-    @property
-    def test_name(self) -> str:
-        return "dot_product"
-
-    def _encode_sentence(self, sentence):
-        tokens = tokenizer(sentence, return_tensors="pt")
-        with torch.no_grad():
-            outputs = model(**tokens)
-        return outputs.last_hidden_state.mean(dim=1).squeeze().numpy()
-
-    def get_metric(self, prompt: str, ground_truth: str, model_prediction: str) -> Union[float, int, bool]:
-        embedding_ground_truth = self._encode_sentence(ground_truth)
-        embedding_model_prediction = self._encode_sentence(model_prediction)
-        dot_product_similarity = np.dot(embedding_ground_truth, embedding_model_prediction)
-        return float(dot_product_similarity)
-
-
-@QaTestRegistry.register("rouge_score")
-class RougeScoreTest(LLMQaTest):
-    @property
-    def test_name(self) -> str:
-        return "rouge_score"
-
-    def get_metric(self, prompt: str, ground_truth: str, model_prediction: str) -> Union[float, int, bool]:
-        scorer = rouge_scorer.RougeScorer(["rouge1"], use_stemmer=True)
-        scores = scorer.score(model_prediction, ground_truth)
-        return float(scores["rouge1"].precision)
-
-
-@QaTestRegistry.register("word_overlap")
-class WordOverlapTest(LLMQaTest):
-    @property
-    def test_name(self) -> str:
-        return "word_overlap"
-
-    def _remove_stopwords(self, text: str) -> str:
-        stop_words = set(stopwords.words("english"))
-        word_tokens = word_tokenize(text)
-        filtered_text = [word for word in word_tokens if word.lower() not in stop_words]
-        return " ".join(filtered_text)
-
-    def get_metric(self, prompt: str, ground_truth: str, model_prediction: str) -> Union[float, int, bool]:
-        cleaned_model_prediction = self._remove_stopwords(model_prediction)
-        cleaned_ground_truth = self._remove_stopwords(ground_truth)
-
-        words_model_prediction = set(cleaned_model_prediction.split())
-        words_ground_truth = set(cleaned_ground_truth.split())
-
-        common_words = words_model_prediction.intersection(words_ground_truth)
-        overlap_percentage = (len(common_words) / len(words_ground_truth)) * 100
-        return float(overlap_percentage)
-
-
-@QaTestRegistry.register("json_valid")
 class JSONValidityTest(LLMQaTest):
     """
     Checks to see if valid json can be parsed from the model output, according
     to langchain_core.utils.json.parse_json_markdown
     The JSON can be wrapped in markdown and this test will still pass
     """
+    def __init__(self):
+        self.json_validity_evaluator = JsonValidityEvaluator()
 
     @property
     def test_name(self) -> str:
         return "json_valid"
 
-    def get_metric(self, prompt: str, ground_truth: str, model_prediction: str) -> float:
-        result = json_validity_evaluator.evaluate_strings(prediction=model_prediction)
+    def get_metric(self, model_prediction: str) -> bool:
+        result = self.json_validity_evaluator.evaluate_strings(prediction=model_prediction)
         binary_res = result["score"]
-        return float(binary_res)
-
-
-class PosCompositionTest(LLMQaTest):
-    def _get_pos_percent(self, text: str, pos_tags: List[str]) -> float:
-        words = word_tokenize(text)
-        tags = pos_tag(words)
-        pos_words = [word for word, tag in tags if tag in pos_tags]
-        total_words = len(text.split(" "))
-        return round(len(pos_words) / total_words, 2)
-
-
-@QaTestRegistry.register("verb_percent")
-class VerbPercent(PosCompositionTest):
-    @property
-    def test_name(self) -> str:
-        return "verb_percent"
-
-    def get_metric(self, prompt: str, ground_truth: str, model_prediction: str) -> float:
-        return self._get_pos_percent(model_prediction, ["VB", "VBD", "VBG", "VBN", "VBP", "VBZ"])
-
-
-@QaTestRegistry.register("adjective_percent")
-class AdjectivePercent(PosCompositionTest):
-    @property
-    def test_name(self) -> str:
-        return "adjective_percent"
-
-    def get_metric(self, prompt: str, ground_truth: str, model_prediction: str) -> float:
-        return self._get_pos_percent(model_prediction, ["JJ", "JJR", "JJS"])
-
-
-@QaTestRegistry.register("noun_percent")
-class NounPercent(PosCompositionTest):
-    @property
-    def test_name(self) -> str:
-        return "noun_percent"
-
-    def get_metric(self, prompt: str, ground_truth: str, model_prediction: str) -> float:
-        return self._get_pos_percent(model_prediction, ["NN", "NNS", "NNP", "NNPS"])
-
-
-# Instantiate tests
-# length_test = LengthTest()
-# jaccard_similarity_test = JaccardSimilarityTest()
-# dot_product_similarity_test = DotProductSimilarityTest()
-# rouge_score_test = RougeScoreTest()
-# word_overlap_test = WordOverlapTest()
-# verb_percent_test = VerbPercent()
-# adjective_percent_test = AdjectivePercent()
-# noun_percent_test = NounPercent()
+        return bool(binary_res)

--- a/llmtune/qa/qa_tests.py
+++ b/llmtune/qa/qa_tests.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from typing import List, Union
 
 from langchain.evaluation import JsonValidityEvaluator
 
@@ -9,6 +8,7 @@ class LLMQaTest(ABC):
     Abstract base class for a test. A test can be computed over a single
     data instance/llm response, and outputs a boolean value (pass or fail).
     """
+
     @property
     @abstractmethod
     def test_name(self) -> str:
@@ -25,6 +25,7 @@ class JSONValidityTest(LLMQaTest):
     to langchain_core.utils.json.parse_json_markdown
     The JSON can be wrapped in markdown and this test will still pass
     """
+
     def __init__(self):
         self.json_validity_evaluator = JsonValidityEvaluator()
 
@@ -32,7 +33,7 @@ class JSONValidityTest(LLMQaTest):
     def test_name(self) -> str:
         return "json_valid"
 
-    def get_metric(self, model_prediction: str) -> bool:
-        result = self.json_validity_evaluator.evaluate_strings(prediction=model_prediction)
+    def test(self, prompt: str, grount_truth: str, model_pred: str) -> bool:
+        result = self.json_validity_evaluator.evaluate_strings(prediction=model_pred)
         binary_res = result["score"]
         return bool(binary_res)

--- a/llmtune/ui/rich_ui.py
+++ b/llmtune/ui/rich_ui.py
@@ -129,7 +129,7 @@ class RichUI(UI):
     # Lifecycle functions
     @staticmethod
     def before_inference():
-        console.rule("[bold pink]:face_with_monocle: Testing")
+        console.rule("[bold pink]:face_with_monocle: Running Inference")
 
     @staticmethod
     def during_inference():

--- a/tests/qa/test_generics.py
+++ b/tests/qa/test_generics.py
@@ -1,7 +1,8 @@
 import pytest
 from pandas import DataFrame
 
-from llmtune.qa.generics import LLMQaTest, LLMTestSuite
+from llmtune.qa.generics import LLMMetricSuite
+from llmtune.qa.qa_metrics import LLMQaMetric
 
 
 @pytest.fixture
@@ -24,49 +25,43 @@ def mock_csv(mocker, example_data):
     mocker.patch("pandas.read_csv", return_value=example_data)
 
 
-class MockQaTest(LLMQaTest):
+class MockQaMetric(LLMQaMetric):
     @property
-    def test_name(self):
+    def metric_name(self):
         return "Mock Accuracy"
 
-    def get_metric(self, prompt, ground_truth, model_pred):
-        return ground_truth == model_pred
+    def get_metric(self, prompt, ground_truth, model_pred) -> int:
+        return int(ground_truth == model_pred)
 
 
 @pytest.fixture
-def mock_tests():
-    return [MockQaTest()]
+def mock_metrics():
+    return [MockQaMetric()]
 
 
-def test_from_csv(mock_csv, mock_tests, example_data):
-    test_suite = LLMTestSuite.from_csv("dummy_path.csv", mock_tests)
-    assert len(test_suite.tests) == 1
-    assert test_suite.prompts[0] == "What is 2+2?"
+def test_from_csv(mock_metrics, mock_csv):
+    suite = LLMMetricSuite.from_csv("dummy_path.csv", mock_metrics)
+    assert len(suite.metrics) == 1
+    assert suite.prompts[0] == "What is 2+2?"
 
 
-def test_run_tests(mock_csv, mock_tests):
-    test_suite = LLMTestSuite.from_csv("dummy_path.csv", mock_tests)
-    results = test_suite.run_tests()
-    assert results["Mock Accuracy"] == [False, True]  # Expected results from the mock test
+def test_compute_metrics(mock_metrics, mock_csv):
+    suite = LLMMetricSuite.from_csv("dummy_path.csv", mock_metrics)
+    results = suite.compute_metrics()
+    assert results["Mock Accuracy"] == [0, 1]  # Expected results from the mock test
 
 
-def test_save_test_results(mock_csv, mock_tests, mocker):
+def test_save_metric_results(mock_metrics, mocker, mock_csv):
     mocker.patch("pandas.DataFrame.to_csv")
-    test_suite = LLMTestSuite.from_csv("dummy_path.csv", mock_tests)
-    test_suite.save_test_results("dummy_save_path.csv")
+    test_suite = LLMMetricSuite.from_csv("dummy_path.csv", mock_metrics)
+    test_suite.save_metric_results("dummy_save_path.csv")
     assert DataFrame.to_csv.called  # Check if pandas DataFrame to_csv was called
 
 
-# def test_print_test_results(mock_csv, mock_tests, mock_rich_ui):
-#     test_suite = LLMTestSuite.from_csv("dummy_path.csv", mock_tests)
-#     test_suite.print_test_results()
-#     assert mock_rich_ui.qa_display_metric_table.called
-
-
-def test_print_test_results(capfd, example_data):
-    tests = [MockQaTest()]
-    test_suite = LLMTestSuite(tests, example_data["Prompt"], example_data["Ground Truth"], example_data["Predicted"])
-    test_suite.print_test_results()
+def test_print_metric_results(capfd, example_data):
+    metrics = [MockQaMetric()]
+    suite = LLMMetricSuite(metrics, example_data["Prompt"], example_data["Ground Truth"], example_data["Predicted"])
+    suite.print_metric_results()
     out, err = capfd.readouterr()
 
     assert "0.5000" in out

--- a/tests/qa/test_qa_metrics.py
+++ b/tests/qa/test_qa_metrics.py
@@ -1,39 +1,105 @@
 import pytest
 
-from llmtune.qa.qa_tests import (
-    JSONValidityTest,
+from llmtune.qa.qa_metrics import (
+    AdjectivePercentMetric,
+    DotProductSimilarityMetric,
+    JaccardSimilarityMetric,
+    JSONValidityMetric,
+    LengthMetric,
+    NounPercentMetric,
+    RougeScoreMetric,
+    VerbPercentMetric,
+    WordOverlapMetric,
 )
 
 
 @pytest.mark.parametrize(
-    "test_class",
+    "test_class,expected_type",
     [
-        JSONValidityTest,
+        (LengthMetric, int),
+        (JaccardSimilarityMetric, float),
+        (DotProductSimilarityMetric, float),
+        (RougeScoreMetric, float),
+        (WordOverlapMetric, float),
+        (VerbPercentMetric, float),
+        (AdjectivePercentMetric, float),
+        (NounPercentMetric, float),
+        (JSONValidityMetric, float),
     ],
 )
-def test_test_return_bool(test_class):
-    """Test to ensure that all tests return pass/fail boolean value."""
+def test_metric_return_type(test_class, expected_type):
     test_instance = test_class()
     prompt = "This is a test prompt."
     ground_truth = "This is a ground truth sentence."
     model_prediction = "This is a model predicted sentence."
 
-    metric_result = test_instance.test(prompt, ground_truth, model_prediction)
-    assert isinstance(metric_result, bool), f"Expected return type bool, but got {type(metric_result)}."
+    # Depending on the test class, the output could be different.
+    metric_result = test_instance.get_metric(prompt, ground_truth, model_prediction)
+    assert isinstance(
+        metric_result, expected_type
+    ), f"Expected return type {expected_type}, but got {type(metric_result)}."
+
+
+def test_length_metric():
+    test = LengthMetric()
+    result = test.get_metric("prompt", "short text", "longer text")
+    assert result == 1, "Length difference should be 1."
+
+
+def test_jaccard_similarity_metric():
+    test = JaccardSimilarityMetric()
+    result = test.get_metric("prompt", "hello world", "world hello")
+    assert result == 1.0, "Jaccard similarity should be 1.0 for the same words in different orders."
+
+
+def test_dot_product_similarity_metric():
+    test = DotProductSimilarityMetric()
+    result = test.get_metric("prompt", "data", "data")
+    assert result >= 0, "Dot product similarity should be non-negative."
+
+
+def test_rouge_score_metric():
+    test = RougeScoreMetric()
+    result = test.get_metric("prompt", "the quick brown fox", "the quick brown fox jumps over the lazy dog")
+    assert result >= 0, "ROUGE precision should be non-negative."
+
+
+def test_word_overlap_metric():
+    test = WordOverlapMetric()
+    result = test.get_metric("prompt", "jump over the moon", "jump around the sun")
+    assert result >= 0, "Word overlap percentage should be non-negative."
+
+
+def test_verb_percent_metric():
+    test = VerbPercentMetric()
+    result = test.get_metric("prompt", "He eats", "He is eating")
+    assert result >= 0, "Verb percentage should be non-negative."
+
+
+def test_adjective_percent_metric():
+    test = AdjectivePercentMetric()
+    result = test.get_metric("prompt", "It is beautiful", "It is extremely beautiful")
+    assert result >= 0, "Adjective percentage should be non-negative."
+
+
+def test_noun_percent_metric():
+    test = NounPercentMetric()
+    result = test.get_metric("prompt", "The cat", "The cat and the dog")
+    assert result >= 0, "Noun percentage should be non-negative."
 
 
 @pytest.mark.parametrize(
     "input_string,expected_value",
     [
-        ('{"Answer": "The cat"}', True),
-        ("{'Answer': 'The cat'}", False),  # Double quotes are required in json
-        ('{"Answer": "The cat",}', False),  # Trailing comma is not allowed
-        ('{"Answer": "The cat", "test": "case"}', True),
-        ('```json\n{"Answer": "The cat"}\n```', True),  # this json block can still be processed
-        ('Here is an example of a JSON block: {"Answer": "The cat"}', False),
+        ('{"Answer": "The cat"}', 1),
+        ("{'Answer': 'The cat'}", 0),  # Double quotes are required in json
+        ('{"Answer": "The cat",}', 0),
+        ('{"Answer": "The cat", "test": "case"}', 1),
+        ('```json\n{"Answer": "The cat"}\n```', 1),  # this json block can still be processed
+        ('Here is an example of a JSON block: {"Answer": "The cat"}', 0),
     ],
 )
-def test_json_valid_metric(input_string: str, expected_value: bool):
-    test = JSONValidityTest()
-    result = test.test("prompt", "The cat", input_string)
+def test_json_valid_metric(input_string: str, expected_value: float):
+    test = JSONValidityMetric()
+    result = test.get_metric("prompt", "The cat", input_string)
     assert result == expected_value, f"JSON validity should be {expected_value} but got {result}."

--- a/tests/qa/test_qa_metrics.py
+++ b/tests/qa/test_qa_metrics.py
@@ -1,105 +1,39 @@
 import pytest
 
-from llmtune.qa.qa_metrics import (
-    AdjectivePercentMetric,
-    DotProductSimilarityMetric,
-    JaccardSimilarityMetric,
-    JSONValidityMetric,
-    LengthMetric,
-    NounPercentMetric,
-    RougeScoreMetric,
-    VerbPercentMetric,
-    WordOverlapMetric,
+from llmtune.qa.qa_tests import (
+    JSONValidityTest,
 )
 
 
 @pytest.mark.parametrize(
-    "test_class,expected_type",
+    "test_class",
     [
-        (LengthMetric, int),
-        (JaccardSimilarityMetric, float),
-        (DotProductSimilarityMetric, float),
-        (RougeScoreMetric, float),
-        (WordOverlapMetric, float),
-        (VerbPercentMetric, float),
-        (AdjectivePercentMetric, float),
-        (NounPercentMetric, float),
-        (JSONValidityMetric, float),
+        JSONValidityTest,
     ],
 )
-def test_metric_return_type(test_class, expected_type):
+def test_test_return_bool(test_class):
+    """Test to ensure that all tests return pass/fail boolean value."""
     test_instance = test_class()
     prompt = "This is a test prompt."
     ground_truth = "This is a ground truth sentence."
     model_prediction = "This is a model predicted sentence."
 
-    # Depending on the test class, the output could be different.
-    metric_result = test_instance.get_metric(prompt, ground_truth, model_prediction)
-    assert isinstance(
-        metric_result, expected_type
-    ), f"Expected return type {expected_type}, but got {type(metric_result)}."
-
-
-def test_length_metric():
-    test = LengthMetric()
-    result = test.get_metric("prompt", "short text", "longer text")
-    assert result == 1, "Length difference should be 1."
-
-
-def test_jaccard_similarity_metric():
-    test = JaccardSimilarityMetric()
-    result = test.get_metric("prompt", "hello world", "world hello")
-    assert result == 1.0, "Jaccard similarity should be 1.0 for the same words in different orders."
-
-
-def test_dot_product_similarity_metric():
-    test = DotProductSimilarityMetric()
-    result = test.get_metric("prompt", "data", "data")
-    assert result >= 0, "Dot product similarity should be non-negative."
-
-
-def test_rouge_score_metric():
-    test = RougeScoreMetric()
-    result = test.get_metric("prompt", "the quick brown fox", "the quick brown fox jumps over the lazy dog")
-    assert result >= 0, "ROUGE precision should be non-negative."
-
-
-def test_word_overlap_metric():
-    test = WordOverlapMetric()
-    result = test.get_metric("prompt", "jump over the moon", "jump around the sun")
-    assert result >= 0, "Word overlap percentage should be non-negative."
-
-
-def test_verb_percent_metric():
-    test = VerbPercentMetric()
-    result = test.get_metric("prompt", "He eats", "He is eating")
-    assert result >= 0, "Verb percentage should be non-negative."
-
-
-def test_adjective_percent_metric():
-    test = AdjectivePercentMetric()
-    result = test.get_metric("prompt", "It is beautiful", "It is extremely beautiful")
-    assert result >= 0, "Adjective percentage should be non-negative."
-
-
-def test_noun_percent_metric():
-    test = NounPercentMetric()
-    result = test.get_metric("prompt", "The cat", "The cat and the dog")
-    assert result >= 0, "Noun percentage should be non-negative."
+    metric_result = test_instance.test(prompt, ground_truth, model_prediction)
+    assert isinstance(metric_result, bool), f"Expected return type bool, but got {type(metric_result)}."
 
 
 @pytest.mark.parametrize(
     "input_string,expected_value",
     [
-        ('{"Answer": "The cat"}', 1),
-        ("{'Answer': 'The cat'}", 0),  # Double quotes are required in json
-        ('{"Answer": "The cat",}', 0),
-        ('{"Answer": "The cat", "test": "case"}', 1),
-        ('```json\n{"Answer": "The cat"}\n```', 1),  # this json block can still be processed
-        ('Here is an example of a JSON block: {"Answer": "The cat"}', 0),
+        ('{"Answer": "The cat"}', True),
+        ("{'Answer': 'The cat'}", False),  # Double quotes are required in json
+        ('{"Answer": "The cat",}', False),  # Trailing comma is not allowed
+        ('{"Answer": "The cat", "test": "case"}', True),
+        ('```json\n{"Answer": "The cat"}\n```', True),  # this json block can still be processed
+        ('Here is an example of a JSON block: {"Answer": "The cat"}', False),
     ],
 )
-def test_json_valid_metric(input_string: str, expected_value: float):
-    test = JSONValidityMetric()
-    result = test.get_metric("prompt", "The cat", input_string)
+def test_json_valid_metric(input_string: str, expected_value: bool):
+    test = JSONValidityTest()
+    result = test.test("prompt", "The cat", input_string)
     assert result == expected_value, f"JSON validity should be {expected_value} but got {result}."

--- a/tests/qa/test_qa_metrics.py
+++ b/tests/qa/test_qa_metrics.py
@@ -1,30 +1,30 @@
 import pytest
 
-from llmtune.qa.qa_tests import (
-    AdjectivePercent,
-    DotProductSimilarityTest,
-    JaccardSimilarityTest,
-    JSONValidityTest,
-    LengthTest,
-    NounPercent,
-    RougeScoreTest,
-    VerbPercent,
-    WordOverlapTest,
+from llmtune.qa.qa_metrics import (
+    AdjectivePercentMetric,
+    DotProductSimilarityMetric,
+    JaccardSimilarityMetric,
+    JSONValidityMetric,
+    LengthMetric,
+    NounPercentMetric,
+    RougeScoreMetric,
+    VerbPercentMetric,
+    WordOverlapMetric,
 )
 
 
 @pytest.mark.parametrize(
     "test_class,expected_type",
     [
-        (LengthTest, int),
-        (JaccardSimilarityTest, float),
-        (DotProductSimilarityTest, float),
-        (RougeScoreTest, float),
-        (WordOverlapTest, float),
-        (VerbPercent, float),
-        (AdjectivePercent, float),
-        (NounPercent, float),
-        (JSONValidityTest, float),
+        (LengthMetric, int),
+        (JaccardSimilarityMetric, float),
+        (DotProductSimilarityMetric, float),
+        (RougeScoreMetric, float),
+        (WordOverlapMetric, float),
+        (VerbPercentMetric, float),
+        (AdjectivePercentMetric, float),
+        (NounPercentMetric, float),
+        (JSONValidityMetric, float),
     ],
 )
 def test_metric_return_type(test_class, expected_type):
@@ -40,50 +40,50 @@ def test_metric_return_type(test_class, expected_type):
     ), f"Expected return type {expected_type}, but got {type(metric_result)}."
 
 
-def test_length_test():
-    test = LengthTest()
+def test_length_metric():
+    test = LengthMetric()
     result = test.get_metric("prompt", "short text", "longer text")
     assert result == 1, "Length difference should be 1."
 
 
-def test_jaccard_similarity_test():
-    test = JaccardSimilarityTest()
+def test_jaccard_similarity_metric():
+    test = JaccardSimilarityMetric()
     result = test.get_metric("prompt", "hello world", "world hello")
     assert result == 1.0, "Jaccard similarity should be 1.0 for the same words in different orders."
 
 
-def test_dot_product_similarity_test():
-    test = DotProductSimilarityTest()
+def test_dot_product_similarity_metric():
+    test = DotProductSimilarityMetric()
     result = test.get_metric("prompt", "data", "data")
     assert result >= 0, "Dot product similarity should be non-negative."
 
 
-def test_rouge_score_test():
-    test = RougeScoreTest()
+def test_rouge_score_metric():
+    test = RougeScoreMetric()
     result = test.get_metric("prompt", "the quick brown fox", "the quick brown fox jumps over the lazy dog")
     assert result >= 0, "ROUGE precision should be non-negative."
 
 
-def test_word_overlap_test():
-    test = WordOverlapTest()
+def test_word_overlap_metric():
+    test = WordOverlapMetric()
     result = test.get_metric("prompt", "jump over the moon", "jump around the sun")
     assert result >= 0, "Word overlap percentage should be non-negative."
 
 
-def test_verb_percent():
-    test = VerbPercent()
+def test_verb_percent_metric():
+    test = VerbPercentMetric()
     result = test.get_metric("prompt", "He eats", "He is eating")
     assert result >= 0, "Verb percentage should be non-negative."
 
 
-def test_adjective_percent():
-    test = AdjectivePercent()
+def test_adjective_percent_metric():
+    test = AdjectivePercentMetric()
     result = test.get_metric("prompt", "It is beautiful", "It is extremely beautiful")
     assert result >= 0, "Adjective percentage should be non-negative."
 
 
-def test_noun_percent():
-    test = NounPercent()
+def test_noun_percent_metric():
+    test = NounPercentMetric()
     result = test.get_metric("prompt", "The cat", "The cat and the dog")
     assert result >= 0, "Noun percentage should be non-negative."
 
@@ -99,7 +99,7 @@ def test_noun_percent():
         ('Here is an example of a JSON block: {"Answer": "The cat"}', 0),
     ],
 )
-def test_json_valid(input_string: str, expected_value: float):
-    test = JSONValidityTest()
+def test_json_valid_metric(input_string: str, expected_value: float):
+    test = JSONValidityMetric()
     result = test.get_metric("prompt", "The cat", input_string)
     assert result == expected_value, f"JSON validity should be {expected_value} but got {result}."

--- a/tests/qa/test_qa_tests.py
+++ b/tests/qa/test_qa_tests.py
@@ -1,105 +1,39 @@
 import pytest
 
-from llmtune.qa.qa_metrics import (
-    AdjectivePercentMetric,
-    DotProductSimilarityMetric,
-    JaccardSimilarityMetric,
-    JSONValidityMetric,
-    LengthMetric,
-    NounPercentMetric,
-    RougeScoreMetric,
-    VerbPercentMetric,
-    WordOverlapMetric,
+from llmtune.qa.qa_tests import (
+    JSONValidityTest,
 )
 
 
 @pytest.mark.parametrize(
-    "test_class,expected_type",
+    "test_class",
     [
-        (LengthMetric, int),
-        (JaccardSimilarityMetric, float),
-        (DotProductSimilarityMetric, float),
-        (RougeScoreMetric, float),
-        (WordOverlapMetric, float),
-        (VerbPercentMetric, float),
-        (AdjectivePercentMetric, float),
-        (NounPercentMetric, float),
-        (JSONValidityMetric, float),
+        JSONValidityTest,
     ],
 )
-def test_metric_return_type(test_class, expected_type):
+def test_test_return_bool(test_class):
+    """Test to ensure that all tests return pass/fail boolean value."""
     test_instance = test_class()
     prompt = "This is a test prompt."
     ground_truth = "This is a ground truth sentence."
     model_prediction = "This is a model predicted sentence."
 
-    # Depending on the test class, the output could be different.
-    metric_result = test_instance.get_metric(prompt, ground_truth, model_prediction)
-    assert isinstance(
-        metric_result, expected_type
-    ), f"Expected return type {expected_type}, but got {type(metric_result)}."
-
-
-def test_length_metric():
-    test = LengthMetric()
-    result = test.get_metric("prompt", "short text", "longer text")
-    assert result == 1, "Length difference should be 1."
-
-
-def test_jaccard_similarity_metric():
-    test = JaccardSimilarityMetric()
-    result = test.get_metric("prompt", "hello world", "world hello")
-    assert result == 1.0, "Jaccard similarity should be 1.0 for the same words in different orders."
-
-
-def test_dot_product_similarity_metric():
-    test = DotProductSimilarityMetric()
-    result = test.get_metric("prompt", "data", "data")
-    assert result >= 0, "Dot product similarity should be non-negative."
-
-
-def test_rouge_score_metric():
-    test = RougeScoreMetric()
-    result = test.get_metric("prompt", "the quick brown fox", "the quick brown fox jumps over the lazy dog")
-    assert result >= 0, "ROUGE precision should be non-negative."
-
-
-def test_word_overlap_metric():
-    test = WordOverlapMetric()
-    result = test.get_metric("prompt", "jump over the moon", "jump around the sun")
-    assert result >= 0, "Word overlap percentage should be non-negative."
-
-
-def test_verb_percent_metric():
-    test = VerbPercentMetric()
-    result = test.get_metric("prompt", "He eats", "He is eating")
-    assert result >= 0, "Verb percentage should be non-negative."
-
-
-def test_adjective_percent_metric():
-    test = AdjectivePercentMetric()
-    result = test.get_metric("prompt", "It is beautiful", "It is extremely beautiful")
-    assert result >= 0, "Adjective percentage should be non-negative."
-
-
-def test_noun_percent_metric():
-    test = NounPercentMetric()
-    result = test.get_metric("prompt", "The cat", "The cat and the dog")
-    assert result >= 0, "Noun percentage should be non-negative."
+    metric_result = test_instance.test(prompt, ground_truth, model_prediction)
+    assert isinstance(metric_result, bool), f"Expected return type bool, but got {type(metric_result)}."
 
 
 @pytest.mark.parametrize(
     "input_string,expected_value",
     [
-        ('{"Answer": "The cat"}', 1),
-        ("{'Answer': 'The cat'}", 0),  # Double quotes are required in json
-        ('{"Answer": "The cat",}', 0),
-        ('{"Answer": "The cat", "test": "case"}', 1),
-        ('```json\n{"Answer": "The cat"}\n```', 1),  # this json block can still be processed
-        ('Here is an example of a JSON block: {"Answer": "The cat"}', 0),
+        ('{"Answer": "The cat"}', True),
+        ("{'Answer': 'The cat'}", False),  # Double quotes are required in json
+        ('{"Answer": "The cat",}', False),  # Trailing comma is not allowed
+        ('{"Answer": "The cat", "test": "case"}', True),
+        ('```json\n{"Answer": "The cat"}\n```', True),  # this json block can still be processed
+        ('Here is an example of a JSON block: {"Answer": "The cat"}', False),
     ],
 )
-def test_json_valid_metric(input_string: str, expected_value: float):
-    test = JSONValidityMetric()
-    result = test.get_metric("prompt", "The cat", input_string)
+def test_json_valid_metric(input_string: str, expected_value: bool):
+    test = JSONValidityTest()
+    result = test.test("prompt", "The cat", input_string)
     assert result == expected_value, f"JSON validity should be {expected_value} but got {result}."

--- a/tests/qa/test_qa_tests.py
+++ b/tests/qa/test_qa_tests.py
@@ -1,0 +1,105 @@
+import pytest
+
+from llmtune.qa.qa_metrics import (
+    AdjectivePercentMetric,
+    DotProductSimilarityMetric,
+    JaccardSimilarityMetric,
+    JSONValidityMetric,
+    LengthMetric,
+    NounPercentMetric,
+    RougeScoreMetric,
+    VerbPercentMetric,
+    WordOverlapMetric,
+)
+
+
+@pytest.mark.parametrize(
+    "test_class,expected_type",
+    [
+        (LengthMetric, int),
+        (JaccardSimilarityMetric, float),
+        (DotProductSimilarityMetric, float),
+        (RougeScoreMetric, float),
+        (WordOverlapMetric, float),
+        (VerbPercentMetric, float),
+        (AdjectivePercentMetric, float),
+        (NounPercentMetric, float),
+        (JSONValidityMetric, float),
+    ],
+)
+def test_metric_return_type(test_class, expected_type):
+    test_instance = test_class()
+    prompt = "This is a test prompt."
+    ground_truth = "This is a ground truth sentence."
+    model_prediction = "This is a model predicted sentence."
+
+    # Depending on the test class, the output could be different.
+    metric_result = test_instance.get_metric(prompt, ground_truth, model_prediction)
+    assert isinstance(
+        metric_result, expected_type
+    ), f"Expected return type {expected_type}, but got {type(metric_result)}."
+
+
+def test_length_metric():
+    test = LengthMetric()
+    result = test.get_metric("prompt", "short text", "longer text")
+    assert result == 1, "Length difference should be 1."
+
+
+def test_jaccard_similarity_metric():
+    test = JaccardSimilarityMetric()
+    result = test.get_metric("prompt", "hello world", "world hello")
+    assert result == 1.0, "Jaccard similarity should be 1.0 for the same words in different orders."
+
+
+def test_dot_product_similarity_metric():
+    test = DotProductSimilarityMetric()
+    result = test.get_metric("prompt", "data", "data")
+    assert result >= 0, "Dot product similarity should be non-negative."
+
+
+def test_rouge_score_metric():
+    test = RougeScoreMetric()
+    result = test.get_metric("prompt", "the quick brown fox", "the quick brown fox jumps over the lazy dog")
+    assert result >= 0, "ROUGE precision should be non-negative."
+
+
+def test_word_overlap_metric():
+    test = WordOverlapMetric()
+    result = test.get_metric("prompt", "jump over the moon", "jump around the sun")
+    assert result >= 0, "Word overlap percentage should be non-negative."
+
+
+def test_verb_percent_metric():
+    test = VerbPercentMetric()
+    result = test.get_metric("prompt", "He eats", "He is eating")
+    assert result >= 0, "Verb percentage should be non-negative."
+
+
+def test_adjective_percent_metric():
+    test = AdjectivePercentMetric()
+    result = test.get_metric("prompt", "It is beautiful", "It is extremely beautiful")
+    assert result >= 0, "Adjective percentage should be non-negative."
+
+
+def test_noun_percent_metric():
+    test = NounPercentMetric()
+    result = test.get_metric("prompt", "The cat", "The cat and the dog")
+    assert result >= 0, "Noun percentage should be non-negative."
+
+
+@pytest.mark.parametrize(
+    "input_string,expected_value",
+    [
+        ('{"Answer": "The cat"}', 1),
+        ("{'Answer': 'The cat'}", 0),  # Double quotes are required in json
+        ('{"Answer": "The cat",}', 0),
+        ('{"Answer": "The cat", "test": "case"}', 1),
+        ('```json\n{"Answer": "The cat"}\n```', 1),  # this json block can still be processed
+        ('Here is an example of a JSON block: {"Answer": "The cat"}', 0),
+    ],
+)
+def test_json_valid_metric(input_string: str, expected_value: float):
+    test = JSONValidityMetric()
+    result = test.get_metric("prompt", "The cat", input_string)
+    assert result == expected_value, f"JSON validity should be {expected_value} but got {result}."


### PR DESCRIPTION
A PR outlining the interface I have in mind for LLM tests. Right now, only the base classes exists, and there's only one test, but it's mainly to show the code structure. More tests to come once the general structure is agreed upon! A lot of this PR is going through and making the code changes to metrics, that silos them into metrics. I have the following working definitions:
A **metric** is a function that takes an LLM prediction, prompt (optional), and gold-standard output (optional) and computes a scalar value. These values can be aggregated meaningfully over a dataset of predictions to shed light on properties of a model.

A **test** is a function that takes an LLM prediction, prompt (optional) and gold-standard output (optional) and computes a **boolean, pass/fail output** that denotes if the model output meets certain criteria or output. These are less about understanding an LLM's properties and more about assuring it can meet specific requirements, with specific prompts.

There can be overlapping underlying functionality between metrics and tests. 

As of right now, there's no way for the user to specify their test suite, but that will come in the form of a spreadsheet interface (next PR). Advanced users can use the library in their own code.